### PR TITLE
Support python 3.10

### DIFF
--- a/jacinle/cli/device.py
+++ b/jacinle/cli/device.py
@@ -48,7 +48,7 @@ def parse_devices(devs, format=DeviceNameFormat.INT):
     if type(devs) is str:
         devs = devs.split(',')
     else:
-        assert isinstance(devs, collections.Sequence)
+        assert isinstance(devs, collections.abc.Sequence)
         if len(devs) == 0:
             devs = devs[0].split(',')
 

--- a/jacinle/nd/batch.py
+++ b/jacinle/nd/batch.py
@@ -18,7 +18,7 @@ def batchify(inputs):
     first = inputs[0]
     if isinstance(first, (tuple, list, collections.UserList)):
         return [batchify([ele[i] for ele in inputs]) for i in range(len(first))]
-    elif isinstance(first, (collections.Mapping, collections.UserDict)):
+    elif isinstance(first, (collections.abc.Mapping, collections.UserDict)):
         return {k: batchify([ele[k] for ele in inputs]) for k in first}
     return np.stack(inputs)
 
@@ -27,7 +27,7 @@ def unbatchify(inputs):
     if isinstance(inputs, (tuple, list, collections.UserList)):
         outputs = [unbatchify(e) for e in inputs]
         return list(map(list, zip(*outputs)))
-    elif isinstance(inputs, (collections.Mapping, collections.UserDict)):
+    elif isinstance(inputs, (collections.abc.Mapping, collections.UserDict)):
         outputs = {k: unbatchify(v) for k, v in inputs.items()}
         first = outputs[0]
         return [{k: outputs[k][i] for k in inputs} for i in range(len(first))]

--- a/jacinle/utils/argument.py
+++ b/jacinle/utils/argument.py
@@ -29,7 +29,7 @@ def get_2dshape(x, default=None, type=int):
     """
     if x is None:
         return default
-    if isinstance(x, collections.Sequence):
+    if isinstance(x, collections.abc.Sequence):
         x = tuple(x)
         if len(x) == 1:
             return x[0], x[0]
@@ -44,7 +44,7 @@ def get_2dshape(x, default=None, type=int):
 def get_3dshape(x, default=None, type=int):
     if x is None:
         return default
-    if isinstance(x, collections.Sequence):
+    if isinstance(x, collections.abc.Sequence):
         x = tuple(x)
         if len(x) == 1:
             return x[0], x[0], x[0]
@@ -59,7 +59,7 @@ def get_3dshape(x, default=None, type=int):
 def get_4dshape(x, default=None, type=int):
     if x is None:
         return default
-    if isinstance(x, collections.Sequence):
+    if isinstance(x, collections.abc.Sequence):
         x = tuple(x)
         if len(x) == 1:
             return 1, x[0], x[0], 1
@@ -83,7 +83,7 @@ def astuple(arr_like):
     """
     if type(arr_like) is tuple:
         return arr_like
-    elif isinstance(arr_like, collections.Sequence) and not isinstance(arr_like, (str, bytes)):
+    elif isinstance(arr_like, collections.abc.Sequence) and not isinstance(arr_like, (str, bytes)):
         return tuple(arr_like)
     else:
         return tuple((arr_like,))

--- a/jacinle/utils/meta.py
+++ b/jacinle/utils/meta.py
@@ -35,7 +35,7 @@ __all__ = [
 
 
 def gofor(v):
-    if isinstance(v, collections.Mapping):
+    if isinstance(v, collections.abc.Mapping):
         return v.items()
     assert_instance(v, collections.Iterable)
     return enumerate(v)
@@ -93,11 +93,11 @@ def first_n(iterable, n=10):
 def stmap(func, iterable):
     if isinstance(iterable, six.string_types):
         return func(iterable)
-    elif isinstance(iterable, (collections.Sequence, collections.UserList)):
+    elif isinstance(iterable, (collections.abc.Sequence, collections.UserList)):
         return [stmap(func, v) for v in iterable]
-    elif isinstance(iterable, collections.Set):
+    elif isinstance(iterable, collections.abc.Set):
         return {stmap(func, v) for v in iterable}
-    elif isinstance(iterable, (collections.Mapping, collections.UserDict)):
+    elif isinstance(iterable, (collections.abc.Mapping, collections.UserDict)):
         return {k: stmap(func, v) for k, v in iterable.items()}
     else:
         return func(iterable)
@@ -174,14 +174,14 @@ def dict_deep_update(a, b):
 
 
 def dict_deep_kv(d, sort=True, sep='.', allow_dict=False):
-    # Not using collections.Sequence to avoid infinite recursion.
-    assert isinstance(d, (tuple, list, collections.Mapping))
+    # Not using collections.abc.Sequence to avoid infinite recursion.
+    assert isinstance(d, (tuple, list, collections.abc.Mapping))
     result = list()
 
     def _dfs(current, prefix=None):
         for key, value in gofor(current):
             current_key = key if prefix is None else prefix + sep + str(key)
-            if isinstance(current[key], (tuple, list, collections.Mapping)):
+            if isinstance(current[key], (tuple, list, collections.abc.Mapping)):
                 if allow_dict:
                     result.append((current_key, value))
                 _dfs(current[key], current_key)

--- a/jactorch/cuda/copy.py
+++ b/jactorch/cuda/copy.py
@@ -35,7 +35,7 @@ def async_copy_to(obj, dev, main_stream=None):
         if main_stream is not None:
             v.record_stream(main_stream)
         return v
-    elif isinstance(obj, collections.Mapping):
+    elif isinstance(obj, collections.abc.Mapping):
         return {k: async_copy_to(o, dev, main_stream) for k, o in obj.items()}
     elif isinstance(obj, (tuple, list, collections.UserList)):
         return [async_copy_to(o, dev, main_stream) for o in obj]

--- a/jactorch/data/collate/collate_v1.py
+++ b/jactorch/data/collate/collate_v1.py
@@ -67,7 +67,7 @@ class VarLengthCollateV1(object):
             return torch.DoubleTensor(batch)
         elif isinstance(batch[0], string_types):
             return batch
-        elif isinstance(batch[0], collections.Mapping):
+        elif isinstance(batch[0], collections.abc.Mapping):
             result = {}
             for key in batch[0]:
                 values = [d[key] for d in batch]
@@ -78,7 +78,7 @@ class VarLengthCollateV1(object):
                 else:
                     result[key] = self(values)
             return result
-        elif isinstance(batch[0], collections.Sequence):
+        elif isinstance(batch[0], collections.abc.Sequence):
             transposed = zip(*batch)
             return [self(samples) for samples in transposed]
 

--- a/jactorch/data/collate/collate_v2.py
+++ b/jactorch/data/collate/collate_v2.py
@@ -91,7 +91,7 @@ class VarLengthCollateV2(object):
             return torch.DoubleTensor(batch)
         elif isinstance(batch[0], string_types):
             return batch
-        elif isinstance(batch[0], collections.Mapping):
+        elif isinstance(batch[0], collections.abc.Mapping):
             result = {}
             for key in batch[0]:
                 values = [d[key] for d in batch]
@@ -107,7 +107,7 @@ class VarLengthCollateV2(object):
                 else:
                     result[key] = self(values)
             return result
-        elif isinstance(batch[0], collections.Sequence):
+        elif isinstance(batch[0], collections.abc.Sequence):
             transposed = zip(*batch)
             return [self(samples) for samples in transposed]
 

--- a/jactorch/data/collate/collate_v3.py
+++ b/jactorch/data/collate/collate_v3.py
@@ -132,7 +132,7 @@ class VarLengthCollateV3(object):
         elif isinstance(batch[0], string_types):
             return batch
 
-        elif isinstance(batch[0], collections.Mapping):
+        elif isinstance(batch[0], collections.abc.Mapping):
             result = dict()
             for key in batch[0]:
                 values = [d[key] for d in batch]
@@ -143,7 +143,7 @@ class VarLengthCollateV3(object):
                 else:
                     result[key] = values
             return result
-        elif isinstance(batch[0], collections.Sequence):
+        elif isinstance(batch[0], collections.abc.Sequence):
             transposed = zip(*batch)
             # Add .{index} only if it's inside a dict already.
             return [

--- a/jactorch/functional/shape.py
+++ b/jactorch/functional/shape.py
@@ -32,7 +32,7 @@ def concat_shape(*shapes):
     """Concatenate shapes into a tuple. The values can be either torch.Size, tuple, list, or int."""
     output = []
     for s in shapes:
-        if isinstance(s, collections.Sequence):
+        if isinstance(s, collections.abc.Sequence):
             output.extend(s)
         else:
             output.append(int(s))

--- a/jactorch/nn/cnn/conv.py
+++ b/jactorch/nn/cnn/conv.py
@@ -114,7 +114,7 @@ class ConvTransposeNDBase(ConvNDBase):
     def forward(self, input, output_size=None, scale_factor=None):
         if output_size is None:
             if scale_factor is not None:
-                if isinstance(scale_factor, collections.Sequence):
+                if isinstance(scale_factor, collections.abc.Sequence):
                     output_size = input.size()[:2] + tuple([s * f for s, f in zip(input.size()[2:], scale_factor)])
                 else:
                     output_size = input.size()[:2] + tuple([s * scale_factor for s in input.size()[2:]])

--- a/jactorch/parallel/dict_gather.py
+++ b/jactorch/parallel/dict_gather.py
@@ -55,11 +55,11 @@ def dict_gather_v1(outputs, target_device, dim=0):
             return Gather.apply(target_device, dim, *outputs)
         elif out is None:
             return None
-        elif isinstance(out, collections.Mapping):
+        elif isinstance(out, collections.abc.Mapping):
             return {k: gather_map([o[k] for o in outputs]) for k in out}
         elif isinstance(out, six.string_types):
             return outputs
-        elif isinstance(out, collections.Sequence):
+        elif isinstance(out, collections.abc.Sequence):
             return type(out)(map(gather_map, zip(*outputs)))
         return outputs
     return gather_map(outputs)

--- a/jactorch/transforms/vision/transforms.py
+++ b/jactorch/transforms/vision/transforms.py
@@ -103,7 +103,7 @@ class TransformBase(object):
         return ret
 
     def __call__(self, feed_dict=None, **kwargs):
-        if feed_dict is not None and not isinstance(feed_dict, collections.Mapping):
+        if feed_dict is not None and not isinstance(feed_dict, collections.abc.Mapping):
             return self.ezcall(feed_dict, **kwargs)
 
         feed_dict = feed_dict or {}
@@ -149,7 +149,7 @@ class TransformFunctionBaseImageOnly(TransformFunctionBase):
 
 class Compose(torch_transforms.Compose):
     def __call__(self, feed_dict=None, **kwargs):
-        if feed_dict is not None and not isinstance(feed_dict, collections.Mapping):
+        if feed_dict is not None and not isinstance(feed_dict, collections.abc.Mapping):
             return self.ezcall(feed_dict, **kwargs)
 
         feed_dict = feed_dict or {}
@@ -162,7 +162,7 @@ class Compose(torch_transforms.Compose):
 
 class RandomApply(torch_transforms.RandomApply):
     def __call__(self, feed_dict=None, **kwargs):
-        if feed_dict is not None and not isinstance(feed_dict, collections.Mapping):
+        if feed_dict is not None and not isinstance(feed_dict, collections.abc.Mapping):
             return self.ezcall(feed_dict, **kwargs)
 
         feed_dict = feed_dict or {}
@@ -175,7 +175,7 @@ class RandomApply(torch_transforms.RandomApply):
 
 class RandomOrder(torch_transforms.RandomOrder):
     def __call__(self, feed_dict=None, **kwargs):
-        if feed_dict is not None and not isinstance(feed_dict, collections.Mapping):
+        if feed_dict is not None and not isinstance(feed_dict, collections.abc.Mapping):
             return self.ezcall(feed_dict, **kwargs)
 
         feed_dict = feed_dict or {}
@@ -188,7 +188,7 @@ class RandomOrder(torch_transforms.RandomOrder):
 
 class RandomChoice(torch_transforms.RandomChoice):
     def __call__(self, feed_dict=None, **kwargs):
-        if feed_dict is not None and not isinstance(feed_dict, collections.Mapping):
+        if feed_dict is not None and not isinstance(feed_dict, collections.abc.Mapping):
             return self.ezcall(feed_dict, **kwargs)
 
         feed_dict = feed_dict or {}
@@ -199,7 +199,7 @@ class RandomChoice(torch_transforms.RandomChoice):
 
 class Lambda(torch_transforms.Lambda):
     def __call__(self, feed_dict=None, **kwargs):
-        if feed_dict is not None and not isinstance(feed_dict, collections.Mapping):
+        if feed_dict is not None and not isinstance(feed_dict, collections.abc.Mapping):
             return self.ezcall(feed_dict, **kwargs)
 
         feed_dict = feed_dict or {}
@@ -342,7 +342,7 @@ class Pad(TransformFunctionBase):
         assert isinstance(padding, (numbers.Number, tuple))
         assert isinstance(fill, (numbers.Number, str, tuple))
         assert mode in ['constant', 'edge', 'reflect', 'symmetric']
-        if isinstance(padding, collections.Sequence) and len(padding) not in [2, 4]:
+        if isinstance(padding, collections.abc.Sequence) and len(padding) not in [2, 4]:
             raise ValueError("Padding must be an int or a 2, or 4 element tuple, not a " +
                              "{} element tuple".format(len(padding)))
 


### PR DESCRIPTION
Hi,
I'm trying to run Jacinle in python 3.10, but it can't work.
# What happen
When running in python 3.10, report
```
AttributeError: module 'collections' has no attribute 'Sequence'
```
# Why happen
`collections.[Sequence|Mapping|Set]` moved into `collections.abc`, according to [python docs](https://docs.python.org/3.9/library/collections.html)
# How I fix this
Just replace all `collections.[Sequence|Mapping|Set]` with `collections.abc.[Sequence|Mapping|Set]`

# Python version
This should work since python>=3.3, according to  [python docs](https://docs.python.org/3/library/collections.abc.html#collections.abc)
**but this not supported in python 2.7**