### PR TITLE
fix sklearn installation error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pyyaml
 tqdm
 pyzmq
 numpy
+scipy
 scikit-learn
-sklearn
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pyyaml
 tqdm
 pyzmq
 numpy
-scipy
+scikit-learn
 sklearn
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ pyyaml
 tqdm
 pyzmq
 numpy
+scipy
 scikit-learn
-sklearn
 matplotlib""".split()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ pyyaml
 tqdm
 pyzmq
 numpy
-scipy
+scikit-learn
 sklearn
 matplotlib""".split()
 


### PR DESCRIPTION
fix the error below when installing Jacinle by pip install -e 
![image](https://github.com/vacancy/Jacinle/assets/63087760/8975a8ef-f1ff-4a4b-bb4f-b06915ad39c1)
